### PR TITLE
Difference for get all patterns.

### DIFF
--- a/src/islearn/learner.py
+++ b/src/islearn/learner.py
@@ -1896,7 +1896,7 @@ class PatternRepository:
         all_patterns: Set[language.Formula] = set(
             functools.reduce(set.__or__, [set(d.values()) for d in self.groups.values()]))
 
-        return all_patterns.intersection(exclude)
+        return all_patterns - exclude
 
     def __str__(self):
         result = ""


### PR DESCRIPTION
The intersection doesn't seem to fit here because otherwise, the learner will have no patterns to check, when not providing allowed patterns.